### PR TITLE
Enqueue/dequeue improvement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ otp_release:
   - "22.0"
   - "22.1"
   - "22.2"
+  - "22.3"
+  - "23.0"
 
 script:
   - make all test

--- a/README.md
+++ b/README.md
@@ -32,11 +32,27 @@ end_per_suite(_) ->
 
 (See src/stubby.erl for more options starting up a server)
 
-In a testcase, make a request to stubby url, then get the most recent request body with:
+By default, a booted stubby serves:
+
+* `/`: always respond with status code 200
+* `/blackhole/[...]`: always respond with status code 204
+
+In a testcase, make a request to stubby URL, then get the most recent request to the **specified** path with:
 
 ```erlang
-{ok, Body} = stubby:get_recent()
+{ok, #{
+  headers := Headers,
+  scheme := Scheme,
+  host := Host,
+  port := Port,
+  path := Path,
+  qs := QueryString,
+  body := Body
+ }} = stubby:get_recent("/path/to/endopoint")
 ```
+
+When no request is recorded yet, this call blocks until the first request is made.
+
 
 See also
 --------

--- a/src/stubby.erl
+++ b/src/stubby.erl
@@ -5,7 +5,7 @@
          start/1,
          start/2,
          stop/0,
-         get_recent/0
+         get_recent/1
         ]).
 
 %% See https://github.com/ninenines/cowboy/blob/master/src/cowboy_router.erl for details.
@@ -51,7 +51,14 @@ start(Host, Routes) ->
     {ok, _} = cowboy:start_clear(
                 ?LISTENER,
                 [{port, 0}],
-                #{env => #{dispatch => Dispatch}}
+                #{
+                  env => #{dispatch => Dispatch},
+                  middlewares => [
+                                  cowboy_router,
+                                  stubby_recorder_middleware,
+                                  cowboy_handler
+                                 ]
+                 }
                ),
     Url = lists:flatten(io_lib:format("http://~s:~p", [Host, ranch:get_port(?LISTENER)])),
     ok = check_ready(Url),
@@ -79,6 +86,6 @@ stop() ->
 
 %% @doc Fetches a record from the recorder FIFO queue.
 %% If empty, the call is blocked until the next enqueue.
--spec get_recent() -> stubby_recorder:result().
-get_recent() ->
-    stubby_recorder:get_recent().
+-spec get_recent(string()) -> stubby_recorder:result().
+get_recent(Path) ->
+    stubby_recorder:get_recent(list_to_binary(Path)).

--- a/src/stubby_blackhole_handler.erl
+++ b/src/stubby_blackhole_handler.erl
@@ -2,21 +2,9 @@
 
 -export([init/2]).
 
-%% @doc A request recording handler mounted to stubby server at <code>/blackhole/[...]</code>.
-%% When requested, the request body is enqueued to recorder FIFO queue, and a response with status code 204 is returned.
-%% A request body can be gzipped when <code>Content-Encoding: gzip</code> is specified.
+%% @doc A blackhole handler mounted to stubby server at <code>/blackhole/[...]</code>.
+%% When requested, a response with status code 204 is returned.
 -spec init(cowboy_req:req(), any()) -> {ok, cowboy_req:req(), any()}.
-init(Req0, State) ->
-    {ok, Data0, Req} = cowboy_req:read_body(Req0, #{length => infinity}),
-    Encoding = cowboy_req:header(<<"content-encoding">>, Req0, undefined),
-    Data = decode_body(Data0, Encoding),
-    ok = stubby_recorder:put_recent(Data),
+init(Req, State) ->
     Resp = cowboy_req:reply(204, #{}, <<>>, Req),
     {ok, Resp, State}.
-
-decode_body(Data, <<"gzip">>) ->
-    zlib:gunzip(Data);
-decode_body(Data, undefined) ->
-    Data;
-decode_body(_, Encoding) ->
-    throw({content_encoding, Encoding}).

--- a/src/stubby_recorder.erl
+++ b/src/stubby_recorder.erl
@@ -12,7 +12,7 @@
               result/0
              ]).
 
--type body() :: binary().
+-type body() :: term().
 -type result() :: {ok, body()}.
 
 -define(RECORDER, ?MODULE).

--- a/src/stubby_recorder.erl
+++ b/src/stubby_recorder.erl
@@ -3,16 +3,9 @@
 -export([
          start/0,
          stop/0,
-         put_recent/1,
-         get_recent/0
+         put_recent/2,
+         get_recent/1
         ]).
-
--ifdef(TEST).
--export([
-         enqueue/2,
-         dequeue/1
-        ]).
--endif.
 
 -export_type([
               body/0,
@@ -37,38 +30,48 @@ stop() ->
 
 %% @private
 start_recorder() ->
-    loop([], []).
+    loop(#{}, #{}).
 
 %% @private
-enqueue(Item, Queue) ->
-    [Item | Queue].
+enqueue(Key, Item, Tree) ->
+    case Tree of
+        #{Key := Queue} ->
+            Tree#{Key => [Item|Queue]};
+        _ ->
+            Tree#{Key => [Item]}
+    end.
 
 %% @private
-dequeue(Queue) ->
-    [Item|L] = lists:reverse(Queue),
-    {Item, lists:reverse(L)}.
+dequeue(Key, Tree) ->
+    case Tree of
+        #{Key := []} ->
+            none;
+        #{Key := Queue} ->
+            [Item|T] = lists:reverse(Queue),
+            {Item, Tree#{Key => lists:reverse(T)}};
+        _ ->
+            none
+    end.
 
 %% @private
 loop(Records, Getters) ->
     receive
-        {put, From, Data} ->
+        {put, From, Key, Data} ->
             From ! ok,
-            case Getters of
-                [] ->
-                    loop(enqueue(Data, Records), []);
+            case dequeue(Key, Getters) of
+                {KeyGetter, Getters1} ->
+                    KeyGetter ! {ok, Data},
+                    loop(Records, Getters1);
                 _ ->
-                    {Getter, L} = dequeue(Getters),
-                    Getter ! {ok, Data},
-                    loop(Records, L)
+                    loop(enqueue(Key, Data, Records), Getters)
             end;
-        {get, Getter} ->
-            case Records of
-                [] ->
-                    loop([], enqueue(Getter, Getters));
+        {get, Getter, Key} ->
+            case dequeue(Key, Records) of
+                {Data, Records1} ->
+                    Getter ! {ok, Data},
+                    loop(Records1, Getters);
                 _ ->
-                    {Data, L} = dequeue(Records),
-                    Getter! {ok, Data},
-                    loop(L, Getters)
+                    loop(Records, enqueue(Key, Getter, Getters))
             end;
         {quit, From} ->
             From ! ok,
@@ -76,18 +79,122 @@ loop(Records, Getters) ->
     end.
 
 %% @doc Puts a record into FIFO queue.
--spec put_recent(body()) -> ok.
-put_recent(Data) ->
-    ?RECORDER ! {put, self(), Data},
+-spec put_recent(term(), body()) -> ok.
+put_recent(Key, Data) ->
+    ?RECORDER ! {put, self(), Key, Data},
     receive X -> X end.
 
 %% @doc Gets a record from FIFO queue.
 %% If empty, the call is blocked until the next enqueue.
--spec get_recent() -> result().
-get_recent() ->
-    ?RECORDER ! {get, self()},
+-spec get_recent(term()) -> result().
+get_recent(Key) ->
+    ?RECORDER ! {get, self(), Key},
     receive X -> X end.
 
 stop_recorder() ->
     ?RECORDER ! {quit, self()},
     receive X -> X end.
+
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+enqueue_test_() ->
+    Cases = [
+             {
+              "0 element",
+              foo,
+              foo,
+              #{bar => []},
+              #{
+                foo => [foo],
+                bar => []
+               }
+             },
+             {
+              "1 element",
+              foo,
+              bar,
+              #{
+                foo => [foo],
+                bar => []
+               },
+              #{
+                foo => [bar, foo],
+                bar => []
+               }
+             },
+             {
+              "2 elements",
+              foo,
+              buz,
+              #{
+                foo => [bar, foo],
+                bar => []
+               },
+              #{
+                foo => [buz, bar, foo],
+                bar => []
+               }
+             }
+            ],
+    F = fun({Title, Key, Input, Queue, Expected}) ->
+                Actual = enqueue(Key, Input, Queue),
+                {Title, ?_assertEqual(Expected, Actual)}
+        end,
+    lists:map(F, Cases).
+
+dequeue_test_() ->
+    Cases = [
+             {
+              "0 element",
+              bar,
+              #{
+                foo => [foo],
+                bar => []
+               },
+              none
+             },
+             {
+              "1 element",
+              foo,
+              #{
+                foo => [foo],
+                bar => []
+               },
+              {foo, #{
+                      foo => [],
+                      bar => []
+                     }}
+             },
+             {
+              "2 elements",
+              foo,
+              #{
+                foo => [bar, foo],
+                bar => []
+               },
+              {foo, #{
+                      foo => [bar],
+                      bar => []
+                     }}
+             },
+             {
+              "3 elements",
+              foo,
+              #{
+                foo => [buz, bar, foo],
+                bar => []
+               },
+              {foo, #{
+                      foo => [buz, bar],
+                      bar => []
+                     }}
+             }
+            ],
+    F = fun({Title, Key, Input, Expected}) ->
+                Actual = dequeue(Key, Input),
+                {Title, ?_assertEqual(Expected, Actual)}
+        end,
+    lists:map(F, Cases).
+-endif.

--- a/src/stubby_recorder_middleware.erl
+++ b/src/stubby_recorder_middleware.erl
@@ -2,14 +2,24 @@
 
 -export([execute/2]).
 
+-type stubby_record() :: #{
+                           headers := map(),
+                           scheme := binary(),
+                           host := binary(),
+                           port := integer(),
+                           path := binary(),
+                           qs := binary(),
+                           body := binary()
+                          }.
+
 %% @doc A request recording middleware for all routes.
-%% When requested, the request body is enqueued to recorder FIFO queue.
+%% When requested, the request is enqueued to recorder FIFO queue.
 %% A request body can be gzipped when <code>Content-Encoding: gzip</code> is specified.
 execute(#{path := Path} = Req0, Env) ->
     {ok, Data0, Req} = cowboy_req:read_body(Req0, #{length => infinity}),
     Encoding = cowboy_req:header(<<"content-encoding">>, Req0, undefined),
     Data = decode_body(Data0, Encoding),
-    ok = stubby_recorder:put_recent(Path, build_record(Req0#{data => Data})),
+    ok = stubby_recorder:put_recent(Path, build_record(Req0#{body => Data})),
     {ok, Req, Env}.
 
 %% @private
@@ -21,9 +31,10 @@ decode_body(_, Encoding) ->
     throw({content_encoding, Encoding}).
 
 %% @private
+-spec build_record(Req::term()) -> stubby_record().
 build_record(Req) ->
     build_record(
-      [headers, scheme, host, port, path, qs, data],
+      [headers, scheme, host, port, path, qs, body],
       Req,
       #{}
      ).

--- a/src/stubby_recorder_middleware.erl
+++ b/src/stubby_recorder_middleware.erl
@@ -1,0 +1,35 @@
+-module(stubby_recorder_middleware).
+
+-export([execute/2]).
+
+%% @doc A request recording middleware for all routes.
+%% When requested, the request body is enqueued to recorder FIFO queue.
+%% A request body can be gzipped when <code>Content-Encoding: gzip</code> is specified.
+execute(#{path := Path} = Req0, Env) ->
+    {ok, Data0, Req} = cowboy_req:read_body(Req0, #{length => infinity}),
+    Encoding = cowboy_req:header(<<"content-encoding">>, Req0, undefined),
+    Data = decode_body(Data0, Encoding),
+    ok = stubby_recorder:put_recent(Path, build_record(Req0#{data => Data})),
+    {ok, Req, Env}.
+
+%% @private
+decode_body(Data, <<"gzip">>) ->
+    zlib:gunzip(Data);
+decode_body(Data, undefined) ->
+    Data;
+decode_body(_, Encoding) ->
+    throw({content_encoding, Encoding}).
+
+%% @private
+build_record(Req) ->
+    build_record(
+      [headers, scheme, host, port, path, qs, data],
+      Req,
+      #{}
+     ).
+
+%% @private
+build_record([], _, Acc) ->
+    Acc;
+build_record([K|T],  Req, Acc) ->
+    build_record(T, Req, Acc#{K => maps:get(K, Req)}).

--- a/test/blackhole_handler_SUITE.erl
+++ b/test/blackhole_handler_SUITE.erl
@@ -38,7 +38,7 @@ request_plain_test(Config) ->
              [],
              []
             ),
-    {ok, #{data := Data}} = stubby:get_recent(?config(path, Config)),
+    {ok, #{body := Data}} = stubby:get_recent(?config(path, Config)),
     ?assertEqual(Body, Data).
 
 request_gzip_test(Config) ->
@@ -54,7 +54,7 @@ request_gzip_test(Config) ->
              [],
              []
             ),
-    {ok, #{data := Data}} = stubby:get_recent(?config(path, Config)),
+    {ok, #{body := Data}} = stubby:get_recent(?config(path, Config)),
     ?assertEqual(Body, Data).
 
 slow_request_awaits_test(Config) ->
@@ -82,7 +82,7 @@ slow_request_awaits_test(Config) ->
        ],
        [
         Data
-        || {ok, #{data := Data}}
+        || {ok, #{body := Data}}
            <- [
                stubby:get_recent(?config(path, Config)),
                stubby:get_recent(?config(path, Config))

--- a/test/blackhole_handler_SUITE.erl
+++ b/test/blackhole_handler_SUITE.erl
@@ -6,8 +6,13 @@
 -include_lib("eunit/include/eunit.hrl").
 
 init_per_suite(Config) ->
-    Url = stubby:start() ++ "/blackhole/",
-    [{url, Url} | Config].
+    Path = "/blackhole/",
+    Url = stubby:start() ++ Path,
+    [
+     {url, Url},
+     {path, Path}
+     | Config
+    ].
 
 end_per_suite(_) ->
     ok = stubby:stop(),
@@ -33,7 +38,8 @@ request_plain_test(Config) ->
              [],
              []
             ),
-    ?assertEqual({ok, Body}, stubby:get_recent()).
+    {ok, #{data := Data}} = stubby:get_recent(?config(path, Config)),
+    ?assertEqual(Body, Data).
 
 request_gzip_test(Config) ->
     Url = ?config(url, Config),
@@ -48,7 +54,8 @@ request_gzip_test(Config) ->
              [],
              []
             ),
-    ?assertEqual({ok, Body}, stubby:get_recent()).
+    {ok, #{data := Data}} = stubby:get_recent(?config(path, Config)),
+    ?assertEqual(Body, Data).
 
 slow_request_awaits_test(Config) ->
     Url = ?config(url, Config),
@@ -68,11 +75,17 @@ slow_request_awaits_test(Config) ->
            end)
      || {Body, Time} <- Reqs
     ],
-    ?assertEqual([
-                  {ok, <<"fast req after 10 ms">>},
-                  {ok, <<"slow req after 100 ms">>}
-                 ],
-                 [
-                  stubby:get_recent(),
-                  stubby:get_recent()
-                 ]).
+    ?assertEqual(
+       [
+        <<"fast req after 10 ms">>,
+        <<"slow req after 100 ms">>
+       ],
+       [
+        Data
+        || {ok, #{data := Data}}
+           <- [
+               stubby:get_recent(?config(path, Config)),
+               stubby:get_recent(?config(path, Config))
+              ]
+       ]
+      ).

--- a/test/default_handler_SUITE.erl
+++ b/test/default_handler_SUITE.erl
@@ -43,7 +43,7 @@ recorded_root_test(_) ->
     {ok, Record} = stubby:get_recent("/"),
     ?assertMatch(
        #{
-         data := <<>>,
+         body := <<>>,
          path := <<"/">>,
          qs := <<>>
         },
@@ -54,7 +54,7 @@ recorded_injected_route_test(_) ->
     {ok, Record} = stubby:get_recent("/hello/world"),
     ?assertMatch(
        #{
-         data := <<>>,
+         body := <<>>,
          path := <<"/hello/world">>,
          qs := <<"foo=bar">>
         },

--- a/test/default_handler_SUITE.erl
+++ b/test/default_handler_SUITE.erl
@@ -24,7 +24,9 @@ end_per_suite(_) ->
 all() ->
     [
      request_root_test,
-     request_injected_route_test
+     request_injected_route_test,
+     recorded_injected_route_test,
+     recorded_root_test
     ].
 
 request_root_test(Config) ->
@@ -34,5 +36,27 @@ request_root_test(Config) ->
 
 request_injected_route_test(Config) ->
     Url = ?config(url, Config),
-    Result = httpc:request(Url ++ "/hello/world"),
+    Result = httpc:request(get, {Url ++ "/hello/world?foo=bar", []}, [], []),
     ?assertMatch({ok, {{"HTTP/1.1", 200, "OK"}, _, "world"}}, Result).
+
+recorded_root_test(_) ->
+    {ok, Record} = stubby:get_recent("/"),
+    ?assertMatch(
+       #{
+         data := <<>>,
+         path := <<"/">>,
+         qs := <<>>
+        },
+       Record
+      ).
+
+recorded_injected_route_test(_) ->
+    {ok, Record} = stubby:get_recent("/hello/world"),
+    ?assertMatch(
+       #{
+         data := <<>>,
+         path := <<"/hello/world">>,
+         qs := <<"foo=bar">>
+        },
+       Record
+      ).

--- a/test/stubby_recorder_tests.erl
+++ b/test/stubby_recorder_tests.erl
@@ -2,62 +2,6 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-enqueue_test_() ->
-    Cases = [
-             {
-              "0 element",
-              foo,
-              [],
-              [foo]
-             },
-             {
-              "1 element",
-              bar,
-              [foo],
-              [bar, foo]
-             },
-             {
-              "2 elements",
-              buz,
-              [bar, foo],
-              [buz, bar, foo]
-             }
-            ],
-    F = fun({Title, Input, Queue, Expected}) ->
-                Actual = stubby_recorder:enqueue(Input, Queue),
-                {Title, ?_assertEqual(Expected, Actual)}
-        end,
-    lists:map(F, Cases).
-
-dequeue_test_() ->
-    Cases = [
-             {
-              "1 element",
-              [foo],
-              {foo, []}
-             },
-             {
-              "2 elements",
-              [bar, foo],
-              {foo, [bar]}
-             },
-             {
-              "3 elements",
-              [buz, bar, foo],
-              {foo, [buz, bar]}
-             },
-             {
-              "4 elements",
-              [hoge, buz, bar, foo],
-              {foo, [hoge, buz, bar]}
-             }
-            ],
-    F = fun({Title, Input, Expected}) ->
-                Actual = stubby_recorder:dequeue(Input),
-                {Title, ?_assertEqual(Expected, Actual)}
-        end,
-    lists:map(F, Cases).
-
 put_get_test_() ->
     {setup,
      fun() ->
@@ -71,8 +15,9 @@ put_get_test_() ->
              [
               {"put/get in fifo order",
                fun() ->
+                       Key = key,
                        Input = [foo, bar, buz],
-                       [stubby_recorder:put_recent(In) || In <- Input],
+                       [stubby_recorder:put_recent(Key, In) || In <- Input],
                        Expected = [
                                    {ok, foo},
                                    {ok, bar},
@@ -80,9 +25,9 @@ put_get_test_() ->
                                   ],
                        ?assertEqual(Expected,
                                     [
-                                     stubby_recorder:get_recent(),
-                                     stubby_recorder:get_recent(),
-                                     stubby_recorder:get_recent()
+                                     stubby_recorder:get_recent(Key),
+                                     stubby_recorder:get_recent(Key),
+                                     stubby_recorder:get_recent(Key)
                                     ]
                                    )
                end
@@ -90,13 +35,14 @@ put_get_test_() ->
               {
                "put/get in async",
                fun() ->
+                       Key = key,
                        Input = [{buz, 100},
                                 {bar, 50},
                                 {foo, 10}
                                ],
                        [spawn(fun() ->
                                      timer:sleep(Time),
-                                     stubby_recorder:put_recent(In)
+                                     stubby_recorder:put_recent(Key, In)
                               end)
                         || {In, Time} <- Input
                        ],
@@ -107,9 +53,9 @@ put_get_test_() ->
                                   ],
                        ?assertEqual(Expected,
                                     [
-                                     stubby_recorder:get_recent(),
-                                     stubby_recorder:get_recent(),
-                                     stubby_recorder:get_recent()
+                                     stubby_recorder:get_recent(Key),
+                                     stubby_recorder:get_recent(Key),
+                                     stubby_recorder:get_recent(Key)
                                     ]
                                    )
                end


### PR DESCRIPTION
* Split queues into endpoints
  * `stubby:get_recent("/foo")` will return the most recent request to `/foo` and `/foo` only
* Record requests at middleware
  * Endpoints to record request can be added without a hustle
* Record not only request body
  * Now req headers, scheme, host, port, path, and query-string are recorded